### PR TITLE
Reload on ok

### DIFF
--- a/accountServices.py
+++ b/accountServices.py
@@ -77,7 +77,7 @@ class Manager:
             try:
                 fileSock.connect((self.fileServerAddress, self.fileServerPort))
             except socket.error, e:
-                self.logger.error("FileServer socket error. WARNING")
+                self.logger.error("FileServer socket error: %s", e[1])
             finally:
                 fileSock.close()
             return True

--- a/static/js/account.js
+++ b/static/js/account.js
@@ -107,12 +107,15 @@ function changeListener(){
 }
 
 function changePassword(){
+    $('#provisionButton').prop("disabled", true);
     var url = '/ums/changePassword/' + netID.val()
     httpClient.get( url, function(result){
 	if( result == 'true' ){
 	    $('#success').show()
 	    $('#fail').hide()
+	    alert("Please check your UT Dallas email for further Instructions");
 	} else {
+	    $('#provisionButton').prop("disabled", false);
 	    $('#success').hide()
 	    $('#fail').show()
 	}
@@ -120,7 +123,7 @@ function changePassword(){
 }
 
 function createAccount(){
-    $('#provisionButton').prop("disabled" ,true);
+    $('#provisionButton').prop("disabled", true);
     var url = '/ums/provision/' + netID.val() + "/" + username.val()
     httpClient.get( url, function(result){
 	if( result == 'true' ){

--- a/static/js/account.js
+++ b/static/js/account.js
@@ -113,7 +113,7 @@ function changePassword(){
 	if( result == 'true' ){
 	    $('#success').show()
 	    $('#fail').hide()
-	    alert("Please check your UT Dallas email for further Instructions");
+	    if(!alert('Please check your UT Dallas email for further Instructions.')){window.location.reload();}
 	} else {
 	    $('#provisionButton').prop("disabled", false);
 	    $('#success').hide()
@@ -129,7 +129,7 @@ function createAccount(){
 	if( result == 'true' ){
 	    $('#success').show()
 	    $('#fail').hide()
-	    alert("Please check your UT Dallas email for further Instructions");
+	    if(!alert('Please check your UT Dallas email for further Instructions.')){window.location.reload();}
 	} else {
 	    $('#provisionButton').prop("disabled", false);
 	    $('#success').hide()


### PR DESCRIPTION
Users aren't reloading between each login/password change.  Even if this is a temporary change while the mac is up front, it will re-enable the button for them, and give each user a clean page.
